### PR TITLE
refactor: add topic names when logging topics created

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -71,7 +71,11 @@ public class WorkloadGenerator implements AutoCloseable {
         Timer timer = new Timer();
         List<String> topics =
                 worker.createTopics(new TopicsInfo(workload.topics, workload.partitionsPerTopic));
-        log.info("Created {} topics in {} ms", topics.size(), timer.elapsedMillis());
+        log.info(
+                "Created {} topics in {} ms, topics: [{}]",
+                topics.size(),
+                timer.elapsedMillis(),
+                String.join(",", topics));
 
         createConsumers(topics);
         createProducers(topics);


### PR DESCRIPTION
Usability fix to know which topics are created during benchmark setup. This helps when running multiple benchmarks and want to look metrics for specific topics.