### PR TITLE
Updated Docker build files so they are working again (#436)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# OpenMessaging Benchmark Framework
+# Fork of the OpenMessaging Benchmark Framework that uses sapmachine 17 docker image
+
+This fork is used to update the outdated offical docker hub image openmessaging/openmessaging-benchmark with sapmachine:17.
+Find more in [./docker/README.md](./docker/README.md).
 
 [![Build](https://github.com/openmessaging/benchmark/actions/workflows/pr-build-and-test.yml/badge.svg)](https://github.com/openmessaging/benchmark/actions/workflows/pr-build-and-test.yml)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -27,7 +30,7 @@ This repository houses user-friendly, cloud-ready benchmarking suites for the fo
 
 Requirements:
 
-* JDK 8
+* JDK 17
 * Maven 3.8.6+
 
 Common build actions:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,12 +12,20 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk
+FROM eclipse-temurin:17
 
 ARG BENCHMARK_TARBALL
 
+# Using ADD instead of COPY because ${BENCHMARK_TARBALL} is an archive that needs to be extracted
 ADD ${BENCHMARK_TARBALL} /
 
 RUN mv openmessaging-benchmark-* /benchmark
 
 WORKDIR /benchmark
+
+# Install vim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y vim tzdata && rm -rf /var/lib/apt/lists/*
+
+# Start a shell by default
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -13,14 +13,21 @@
 #
 
 # Build the Project
-FROM maven:latest as build
+FROM maven:3.9.9-eclipse-temurin-17 as build
 COPY . /benchmark
 WORKDIR /benchmark
 RUN mvn install
 
 # Create the benchmark image
-FROM openjdk:8-jdk
+FROM eclipse-temurin:17
 COPY --from=build /benchmark/package/target/openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz /
 RUN mkdir /benchmark && tar -xzf openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz -C /benchmark --strip=1
 RUN rm /openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz
 WORKDIR /benchmark
+
+# Install vim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y vim tzdata && rm -rf /var/lib/apt/lists/*
+
+# Start a shell by default
+CMD ["/bin/bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,24 +1,31 @@
 # OpenMessaging Benchmark Framework Docker
 
+## Precondition
+
+You need to install [Eclipse Temurin 17](https://adoptium.net/)
+and set the JAVA_HOME environment variable to its installation directory.
+
+## Building the image
+
 You can use either of the Dockerfiles - `./docker/Dockerfile` or `./docker/Dockerfile.build` based on your needs.
 
 ### `Dockerfile`
 
-Uses `openjdk-8` and takes `BENCHMARK_TARBALL` as an argument.  
+Uses `eclipse-temurin:17` and takes `BENCHMARK_TARBALL` as an argument.
 While using this Dockerfile, you will need to build the project locally **first**.
 
 ```
 #> mvn build
 #> export BENCHMARK_TARBALL=package/target/openmessaging-benchmark-<VERSION>-SNAPSHOT-bin.tar.gz
-#> docker build --build-arg BENCHMARK_TARBALL . -f docker/Dockerfile
+#> docker build -t openmessaging-benchmark:latest --build-arg BENCHMARK_TARBALL . -f docker/Dockerfile
 ```
 
 ### `Dockerfile.build`
 
-Uses the latest version of `maven` in order to build the project, and then use `openjdk-8` as runtime.  
-This Dockerfile has no dependency (you do not need Mavent to be installed locally).
+Uses the latest version of `maven` in order to build the project, and then uses `eclipse-temurin:17` as runtime.
+This Dockerfile has no dependency (you do not need Maven to be installed locally).
 
 ```
-#> docker build . -f docker/Dockerfile.build
+#> docker build -t openmessaging-benchmark:latest . -f docker/Dockerfile.build
 ```
 


### PR DESCRIPTION
* Updated README.md

* Squash merge feature/update-docker-image into master

* Install vim on the openmessaging image

* Start shell by default

* Start shell by default also for Dockerfile.build

* Use eclipse-temurin:17, fix apt install, and document image tagging\n\n- Switch base images to eclipse-temurin:17 for best practice\n- Remove version pinning for vim/tzdata to avoid apt errors\n- Update README to show -t usage and new image names\n- Prevent dangling images by tagging in build commands