### PR TITLE
cloud-vm(ansible): support multiple drivers on uploading plans

### DIFF
--- a/deployment/cloud-vm/README.md
+++ b/deployment/cloud-vm/README.md
@@ -117,7 +117,16 @@ make open_prometheus
 
 ### Preparing OMB plans
 
-Adapt the OMB driver template at [`drivers/kafka.yaml`](./drivers/kafka.yaml) to your needs, e.g., set the topic, and client configurations.
+You can create multiple driver configurations in the [`drivers/`](./drivers) directory. Each YAML file in this directory will be processed as a separate driver configuration.
+
+For example:
+- `drivers/default.yaml` - Basic Kafka configuration
+- `drivers/diskless-low-throughput.yaml` - Diskless configuration for low throughput
+- `drivers/diskless-high-throughput.yaml` - Diskless configuration optimized for high throughput
+
+When uploaded, each driver template will be named with the pattern `{svc_name}-{template_name}.yaml` on the worker nodes. For instance, if your service is named `my-kafka` and you have `drivers/diskless-high-throughput.yaml`, it will be uploaded as `my-kafka-diskless-high-throughput.yaml`.
+
+Adapt the OMB driver templates to your needs, e.g., set the topic and client configurations.
 
 The playbook will use your `avn` CLI to gather the necessary connection information for Kafka clusters.
 
@@ -126,7 +135,7 @@ Then, validate and add any missing workload plans to the [`./workloads`](./workl
 Once all is set locally, run the Ansible playbook to upload the plans to OMB workers:
 
 ```shell
-ansible-playbook -i hosts.yaml upload_plans.yaml
+ansible-playbook -i hosts.yaml upload.yaml -e svc_name=<your-service-name>
 ```
 
 or with `make`:
@@ -158,9 +167,14 @@ Once connected, you can start OMB workloads with:
 ```shell
 sudo -i
 cd /opt/benchmark
-./bin/benchmark --drivers plans/drivers/$SVC_NAME.yaml --workloads workloads/$WORKLOAD_NAME.yaml
+# List available drivers
+ls plans/drivers/
+# Run with a specific driver configuration
+./bin/benchmark --drivers plans/drivers/$SVC_NAME-diskless-high-throughput.yaml --workloads workloads/$WORKLOAD_NAME.yaml
+# or with the default driver
+./bin/benchmark --drivers plans/drivers/$SVC_NAME-default.yaml --workloads workloads/$WORKLOAD_NAME.yaml
 # optionally add -x to increase the number of consumer nodes to 2/3 of the available nodes
-./bin/benchmark --drivers plans/drivers/$SVC_NAME.yaml --workloads workloads/$WORKLOAD_NAME.yaml -x
+./bin/benchmark --drivers plans/drivers/$SVC_NAME-diskless-high-throughput.yaml --workloads workloads/$WORKLOAD_NAME.yaml -x
 ```
 
 ### Explore the results

--- a/deployment/cloud-vm/drivers/default.yaml
+++ b/deployment/cloud-vm/drivers/default.yaml
@@ -11,11 +11,9 @@ commonConfig: |
   ssl.truststore.type=PEM
   ssl.truststore.location=/opt/benchmark/plans/drivers/{{ svc_name }}-ca.pem
   # add more common client configs here
-  
 producerConfig: |
-  linger.ms=10
   # add more producer configs here
-  
 consumerConfig: |
   auto.offset.reset=earliest
   # add more consumer configs here
+

--- a/deployment/cloud-vm/drivers/diskless-high-throughput.yaml
+++ b/deployment/cloud-vm/drivers/diskless-high-throughput.yaml
@@ -1,0 +1,29 @@
+name: {{ svc_name }}
+driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
+topicConfig: |
+  # add topic configs here
+  diskless.enable=true
+replicationFactor: 1  # required by diskless topics
+commonConfig: |
+  bootstrap.servers={{ kafka_service_uri }}
+  security.protocol=SSL
+  ssl.keystore.type=PEM
+  ssl.keystore.location=/opt/benchmark/plans/drivers/{{ svc_name }}-service.pem
+  ssl.truststore.type=PEM
+  ssl.truststore.location=/opt/benchmark/plans/drivers/{{ svc_name }}-ca.pem
+  # add more common client configs here
+  client.id=omb,diskless_az={zone.id}
+  metadata.recovery.strategy=rebootstrap
+  metadata.max.age.ms=60000
+producerConfig: |
+  linger.ms=100
+  # add more producer configs here
+  batch.size=1000000
+  max.request.size=4000000
+consumerConfig: |
+  auto.offset.reset=earliest
+  # add more consumer configs here
+  max.partition.fetch.bytes=8000000
+  fetch.max.bytes=64000000
+  fetch.max.wait.ms=500
+  fetch.min.bytes=4000000

--- a/deployment/cloud-vm/drivers/diskless-low-throughput.yaml
+++ b/deployment/cloud-vm/drivers/diskless-low-throughput.yaml
@@ -1,0 +1,29 @@
+name: {{ svc_name }}
+driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
+topicConfig: |
+  # add topic configs here
+  diskless.enable=true
+replicationFactor: 1  # required by diskless topics
+commonConfig: |
+  bootstrap.servers={{ kafka_service_uri }}
+  security.protocol=SSL
+  ssl.keystore.type=PEM
+  ssl.keystore.location=/opt/benchmark/plans/drivers/{{ svc_name }}-service.pem
+  ssl.truststore.type=PEM
+  ssl.truststore.location=/opt/benchmark/plans/drivers/{{ svc_name }}-ca.pem
+  # add more common client configs here
+  client.id=omb,diskless_az={zone.id}
+  metadata.recovery.strategy=rebootstrap
+  metadata.max.age.ms=60000
+producerConfig: |
+  linger.ms=100
+  # add more producer configs here
+  batch.size=200000
+  max.request.size=1000000
+consumerConfig: |
+  auto.offset.reset=earliest
+  # add more consumer configs here
+  max.partition.fetch.bytes=4000000
+  fetch.max.bytes=10000000
+  fetch.max.wait.ms=500
+  fetch.min.bytes=1000000

--- a/deployment/cloud-vm/upload.yaml
+++ b/deployment/cloud-vm/upload.yaml
@@ -14,10 +14,12 @@
     - name: Set a kafka service URI fact
       set_fact:
         kafka_service_uri: "{{ get_service_uri_result.stdout }}"
+      run_once: true
 
     - name: Display the kafka service URI
       debug:
         var: kafka_service_uri
+      run_once: true
 
     - name: Get credentials
       shell: "avn service user-creds-download {{ svc_name }} --username avnadmin"
@@ -40,10 +42,22 @@
         src: ./drivers/service.pem
         dest: "/opt/benchmark/plans/drivers/{{ svc_name }}-service.pem"
 
+    - name: Find driver templates
+      find:
+        paths: ./drivers
+        patterns: "*.yaml"
+      delegate_to: localhost
+      run_once: true
+      become: false
+      register: driver_templates
+
     - name: Prepare Drivers
       template:
-        src: ./drivers/kafka.yaml
-        dest: "/opt/benchmark/plans/drivers/{{ svc_name }}.yaml"
+        src: "{{ item.path }}"
+        dest: "/opt/benchmark/plans/drivers/{{ svc_name }}-{{ item.path | basename }}"
+      loop: "{{ driver_templates.files }}"
+      loop_control:
+        label: "{{ item.path | basename }} -> {{ svc_name }}-{{ item.path | basename }}"
 
     - name: Upload Workloads
       copy:


### PR DESCRIPTION
Allow to pass multiple drivers so svc client configurations can be tested with different tuning.
This is prefered to having to manually edit the same drivers and lose track of previous versions.