### PR TITLE
add mixed workloads

### DIFF
--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
@@ -13,10 +13,21 @@
  */
 package io.openmessaging.benchmark.driver.kafka;
 
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class Config {
     public short replicationFactor;
 
     public String topicConfig;
+
+    /**
+     * Optional weighted topic configurations for mixed workloads. Each entry's {@code config} is
+     * merged on top of {@link #topicConfig} — put shared defaults in {@link #topicConfig} and
+     * per-group overrides here. Topics are distributed proportionally by weight.
+     */
+    public List<WeightedTopicConfig> weightedTopicConfigs = new ArrayList<>();
 
     public String commonConfig;
 

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
@@ -120,11 +120,92 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
 
     @Override
     public CompletableFuture<Void> createTopics(List<TopicInfo> topicInfos) {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        Map<String, String> topicConfigs = new HashMap<>((Map) topicProperties);
-        KafkaTopicCreator topicCreator =
-                new KafkaTopicCreator(admin, topicConfigs, config.replicationFactor);
-        return topicCreator.create(topicInfos);
+        if (config.weightedTopicConfigs == null || config.weightedTopicConfigs.isEmpty()) {
+            return createAllWithConfig(topicInfos, baseTopicConfigs());
+        }
+        return createWithWeightedConfigs(topicInfos);
+    }
+
+    private CompletableFuture<Void> createAllWithConfig(
+            List<TopicInfo> topicInfos, Map<String, String> topicConfigs) {
+        return new KafkaTopicCreator(admin, topicConfigs, config.replicationFactor).create(topicInfos);
+    }
+
+    private CompletableFuture<Void> createWithWeightedConfigs(List<TopicInfo> topicInfos) {
+        int[] counts = allocateByWeight(topicInfos.size(), config.weightedTopicConfigs);
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        int offset = 0;
+        for (int i = 0; i < config.weightedTopicConfigs.size(); i++) {
+            int count = counts[i];
+            if (count == 0) {
+                continue;
+            }
+            List<TopicInfo> group = topicInfos.subList(offset, offset + count);
+            offset += count;
+
+            Map<String, String> merged = mergeConfigs(config.weightedTopicConfigs.get(i).config);
+            futures.add(createAllWithConfig(group, merged));
+        }
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Map<String, String> baseTopicConfigs() {
+        return new HashMap<>((Map) topicProperties);
+    }
+
+    private Map<String, String> mergeConfigs(String overrideConfig) {
+        Map<String, String> merged = baseTopicConfigs();
+        if (overrideConfig == null || overrideConfig.trim().isEmpty()) {
+            return merged;
+        }
+        Properties overrides = new Properties();
+        try {
+            overrides.load(new StringReader(overrideConfig));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse topic config override", e);
+        }
+        overrides.forEach((k, v) -> merged.put((String) k, (String) v));
+        return merged;
+    }
+
+    static int[] allocateByWeight(int total, List<WeightedTopicConfig> configs) {
+        double totalWeight = 0;
+        for (WeightedTopicConfig c : configs) {
+            totalWeight += c.weight;
+        }
+        if (totalWeight <= 0) {
+            throw new IllegalArgumentException("Total weight must be positive");
+        }
+
+        double[] exact = new double[configs.size()];
+        int[] counts = new int[configs.size()];
+        int allocated = 0;
+
+        for (int i = 0; i < configs.size(); i++) {
+            exact[i] = (configs.get(i).weight / totalWeight) * total;
+            counts[i] = (int) Math.floor(exact[i]);
+            allocated += counts[i];
+        }
+
+        int remaining = total - allocated;
+        while (remaining > 0) {
+            double maxFrac = -1;
+            int maxIdx = 0;
+            for (int i = 0; i < configs.size(); i++) {
+                double frac = exact[i] - counts[i];
+                if (frac > maxFrac) {
+                    maxFrac = frac;
+                    maxIdx = i;
+                }
+            }
+            counts[maxIdx]++;
+            exact[maxIdx] = counts[maxIdx];
+            remaining--;
+        }
+
+        return counts;
     }
 
     @Override

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/WeightedTopicConfig.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/WeightedTopicConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.kafka;
+
+/**
+ * A topic configuration with an associated weight for proportional distribution across topics. When
+ * multiple entries are specified, topics are allocated to each config proportionally based on the
+ * relative weights. Each entry's config is merged on top of the base {@code topicConfig} — so
+ * shared defaults go in {@code topicConfig} and per-group overrides go here.
+ */
+public class WeightedTopicConfig {
+    public double weight;
+    public String config;
+
+    public WeightedTopicConfig() {}
+
+    public WeightedTopicConfig(double weight, String config) {
+        this.weight = weight;
+        this.config = config;
+    }
+}

--- a/driver-kafka/src/test/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriverWeightedConfigTest.java
+++ b/driver-kafka/src/test/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriverWeightedConfigTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class KafkaBenchmarkDriverWeightedConfigTest {
+
+    @Nested
+    class AllocateByWeight {
+
+        @Test
+        void exactEvenSplit() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(0.5, "a"), new WeightedTopicConfig(0.5, "b"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(10, configs);
+
+            assertThat(counts).containsExactly(5, 5);
+        }
+
+        @Test
+        void unevenWeights() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(0.7, "a"), new WeightedTopicConfig(0.3, "b"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(10, configs);
+
+            assertThat(counts).containsExactly(7, 3);
+        }
+
+        @Test
+        void singleTopicGoesToFirstConfig() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(0.5, "a"), new WeightedTopicConfig(0.5, "b"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(1, configs);
+
+            assertThat(counts).containsExactly(1, 0);
+        }
+
+        @Test
+        void threeWaySplit() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(
+                            new WeightedTopicConfig(1, "a"),
+                            new WeightedTopicConfig(1, "b"),
+                            new WeightedTopicConfig(1, "c"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(10, configs);
+
+            assertThat(Arrays.stream(counts).sum()).isEqualTo(10);
+            for (int count : counts) {
+                assertThat(count).isBetween(3, 4);
+            }
+        }
+
+        @Test
+        void weightsAreNormalized() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(2.0, "a"), new WeightedTopicConfig(2.0, "b"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(6, configs);
+
+            assertThat(counts).containsExactly(3, 3);
+        }
+
+        @Test
+        void throwsOnZeroTotalWeight() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(0, "a"), new WeightedTopicConfig(0, "b"));
+
+            assertThatThrownBy(() -> KafkaBenchmarkDriver.allocateByWeight(10, configs))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <checkstyle.version>10.3.3</checkstyle.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
         <log4j.version>2.20.0</log4j.version>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.34</lombok.version>
         <jackson.version>2.13.2</jackson.version>
         <jcommander.version>1.48</jcommander.version>
         <junit.jupiter.version>5.9.0</junit.jupiter.version>
@@ -442,6 +442,13 @@
                                 <showDeprecation>true</showDeprecation>
                                 <showWarnings>true</showWarnings>
                                 <optimize>true</optimize>
+                                <annotationProcessorPaths>
+                                    <path>
+                                        <groupId>org.projectlombok</groupId>
+                                        <artifactId>lombok</artifactId>
+                                        <version>${lombok.version}</version>
+                                    </path>
+                                </annotationProcessorPaths>
                             </configuration>
                         </plugin>
                     </plugins>


### PR DESCRIPTION
Example driver:

```yaml
"name": inkless-kafka-azure-aku-9
"driverClass": io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver

# Mixed workload
"topicConfig": ""
# 50/50 default vs diskless topics
"weightedTopicConfigs":
  - weight: 0.5
    config: |
      diskless.enable=true
  - weight: 0.5
    config: ""

# No explicit diskless config - cluster-level remote.storage.enable handles this
"topicConfig": ""

# Use -1 (cluster default) so diskless topics get the required RF=1
# while classic topics get the cluster default RF (3). A fixed RF=3 is
# rejected for diskless topics ("must be 1 or -1 when managed replicas are disabled").
"replicationFactor": -1
"commonConfig": |
  bootstrap.servers=kafka-29af71cb-inkless.k.aivencloud.com:12040

  security.protocol=SSL
  ssl.keystore.type=PEM
  ssl.keystore.location=/opt/benchmark/generated/drivers/kafka-29af71cb-svc.pem
  ssl.truststore.type=PEM
  ssl.truststore.location=/opt/benchmark/generated/drivers/kafka-29af71cb-ca.pem
  
  client.id=omb-prod
  diskless_az={zone.id}

  metadata.recovery.strategy=rebootstrap
producerConfig: |
  linger.ms=100
  batch.size=1000000
  max.request.size=4000000
consumerConfig: |
  auto.offset.reset=earliest
  max.partition.fetch.bytes=8000000
  fetch.max.bytes=64000000
  fetch.max.wait.ms=500
  fetch.min.bytes=4000000
```