### PR TITLE
Specific bytes target

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -62,6 +62,23 @@ public class Workload {
      */
     public double backlogDrainRatio = 1.0;
 
+    /**
+     * If greater than 0, the benchmark phase is bounded by produced volume rather than by time. The
+     * producers will publish until this many bytes (counted as {@code messages * messageSize}) have
+     * been produced during the benchmark phase, after which the producers are throttled to a halt and
+     * the run completes once the consumers have drained the produced data.
+     *
+     * <p>With multiple subscriptions the consumed volume is a multiple of the produced volume, e.g.
+     * producing 1GB with {@code subscriptionsPerTopic = 3} results in 3GB consumed across the
+     * subscriptions. The fraction of the produced data that must be consumed before completing is
+     * governed by {@link #backlogDrainRatio}.
+     *
+     * <p>When set, {@link #testDurationMinutes} is ignored and a fixed {@link #producerRate} is
+     * required (the sustainable-rate prober cannot be used). Cannot be combined with {@link
+     * #consumerBacklogSizeGB}.
+     */
+    public long produceBytesTarget = 0;
+
     public int testDurationMinutes;
 
     public int warmupDurationMinutes = 1;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -65,6 +65,22 @@ public class WorkloadGenerator implements AutoCloseable {
             throw new IllegalArgumentException(
                     "Cannot probe producer sustainable rate when building backlog");
         }
+
+        if (workload.produceBytesTarget > 0) {
+            if (workload.producerRate == 0) {
+                throw new IllegalArgumentException(
+                        "Cannot probe producer sustainable rate when bounding the run by produced volume; "
+                                + "set a fixed producerRate");
+            }
+            if (workload.consumerBacklogSizeGB > 0) {
+                throw new IllegalArgumentException(
+                        "produceBytesTarget cannot be combined with consumerBacklogSizeGB");
+            }
+            if (workload.messageSize <= 0) {
+                throw new IllegalArgumentException(
+                        "messageSize must be positive when using produceBytesTarget");
+            }
+        }
     }
 
     public TestResult run() throws Exception {
@@ -127,7 +143,7 @@ public class WorkloadGenerator implements AutoCloseable {
 
         if (workload.warmupDurationMinutes > 0) {
             log.info("----- Starting warm-up traffic ({}m) ------", workload.warmupDurationMinutes);
-            printAndCollectStats(workload.warmupDurationMinutes, TimeUnit.MINUTES);
+            printAndCollectStats(workload.warmupDurationMinutes, TimeUnit.MINUTES, false);
         }
 
         if (workload.consumerBacklogSizeGB > 0) {
@@ -142,9 +158,17 @@ public class WorkloadGenerator implements AutoCloseable {
         }
 
         worker.resetStats();
-        log.info("----- Starting benchmark traffic ({}m)------", workload.testDurationMinutes);
+        if (workload.produceBytesTarget > 0) {
+            log.info(
+                    "----- Starting benchmark traffic (until {} bytes produced) ------",
+                    workload.produceBytesTarget);
+        } else {
+            log.info("----- Starting benchmark traffic ({}m)------", workload.testDurationMinutes);
+        }
 
-        TestResult result = printAndCollectStats(workload.testDurationMinutes, TimeUnit.MINUTES);
+        TestResult result =
+                printAndCollectStats(
+                        workload.testDurationMinutes, TimeUnit.MINUTES, workload.produceBytesTarget > 0);
         runCompleted = true;
 
         worker.stopAll();
@@ -334,13 +358,32 @@ public class WorkloadGenerator implements AutoCloseable {
     }
 
     @SuppressWarnings({"checkstyle:LineLength", "checkstyle:MethodLength"})
-    private TestResult printAndCollectStats(long testDurations, TimeUnit unit) throws IOException {
+    private TestResult printAndCollectStats(long testDurations, TimeUnit unit, boolean volumeBounded)
+            throws IOException {
         long startTime = System.nanoTime();
 
         // Print report stats
         long oldTime = System.nanoTime();
 
-        long testEndTime = testDurations > 0 ? startTime + unit.toNanos(testDurations) : Long.MAX_VALUE;
+        long testEndTime =
+                !volumeBounded && testDurations > 0
+                        ? startTime + unit.toNanos(testDurations)
+                        : Long.MAX_VALUE;
+
+        // Volume-bounded control state. The cumulative counters returned by the worker include the
+        // probe and warm-up traffic, so we baseline them at the start of the benchmark phase and
+        // measure produced/consumed volume relative to that baseline.
+        final long produceTargetMessages =
+                volumeBounded ? workload.produceBytesTarget / workload.messageSize : 0;
+        final CountersStats baseline = volumeBounded ? worker.getCountersStats() : new CountersStats();
+        final long baselineSent = baseline.messagesSent;
+        final long baselineReceived = baseline.messagesReceived;
+        // Poll the lightweight counters more frequently than the 10s stats cadence to keep the
+        // produced-volume overshoot small at high publish rates.
+        final long pollMillis = volumeBounded ? 250 : 10_000;
+        final long statsPeriodNanos = TimeUnit.SECONDS.toNanos(10);
+        boolean producersThrottled = false;
+        long requiredConsumedMessages = 0;
 
         TestResult result = new TestResult();
         result.workload = workload.name;
@@ -353,14 +396,55 @@ public class WorkloadGenerator implements AutoCloseable {
 
         while (true) {
             try {
-                Thread.sleep(10000);
+                Thread.sleep(pollMillis);
             } catch (InterruptedException e) {
                 break;
             }
 
+            long now = System.nanoTime();
+
+            boolean volumeComplete = false;
+            if (volumeBounded) {
+                CountersStats counters = worker.getCountersStats();
+                long produced = counters.messagesSent - baselineSent;
+                long consumed = counters.messagesReceived - baselineReceived;
+
+                if (!producersThrottled && produced >= produceTargetMessages) {
+                    requiredConsumedMessages =
+                            (long)
+                                    (workload.subscriptionsPerTopic
+                                            * produced
+                                            * workload.backlogDrainRatio);
+                    log.info(
+                            "----- Produce target reached: {} messages ({} bytes) produced. "
+                                    + "Throttling producers and draining {} messages to consumers -----",
+                            produced,
+                            produced * (long) workload.messageSize,
+                            requiredConsumedMessages);
+                    worker.adjustPublishRate(0);
+                    producersThrottled = true;
+                }
+
+                if (producersThrottled && consumed >= requiredConsumedMessages) {
+                    log.info(
+                            "----- Consume target reached: {} messages ({} bytes) consumed -----",
+                            consumed,
+                            consumed * (long) workload.messageSize);
+                    volumeComplete = true;
+                }
+            }
+
+            boolean timeComplete = now >= testEndTime && !needToWaitForBacklogDraining;
+            boolean complete = volumeComplete || timeComplete;
+
+            // Only gather and log the period stats on the 10s cadence (or when completing), even
+            // though the volume control loop polls more frequently.
+            if (!complete && (now - oldTime) < statsPeriodNanos) {
+                continue;
+            }
+
             PeriodStats stats = worker.getPeriodStats();
 
-            long now = System.nanoTime();
             double elapsed = (now - oldTime) / 1e9;
 
             double publishRate = stats.messagesSent / elapsed;
@@ -434,7 +518,7 @@ public class WorkloadGenerator implements AutoCloseable {
                     microsToMillis(stats.endToEndLatency.getValueAtPercentile(99.99)));
             result.endToEndLatencyMax.add(microsToMillis(stats.endToEndLatency.getMaxValue()));
 
-            if (now >= testEndTime && !needToWaitForBacklogDraining) {
+            if (complete) {
                 CumulativeLatencies agg = worker.getCumulativeLatencies();
                 log.info(
                         "----- Aggregated Pub Latency (ms) avg: {} - 50%: {} - 95%: {} - 99%: {} - 99.9%: {} - 99.99%: {} - Max: {} | Pub Delay (us)  avg: {} - 50%: {} - 95%: {} - 99%: {} - 99.9%: {} - 99.99%: {} - Max: {}",

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
@@ -13,10 +13,21 @@
  */
 package io.openmessaging.benchmark.driver.kafka;
 
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class Config {
     public short replicationFactor;
 
     public String topicConfig;
+
+    /**
+     * Optional weighted topic configurations for mixed workloads. Each entry's {@code config} is
+     * merged on top of {@link #topicConfig} — put shared defaults in {@link #topicConfig} and
+     * per-group overrides here. Topics are distributed proportionally by weight.
+     */
+    public List<WeightedTopicConfig> weightedTopicConfigs = new ArrayList<>();
 
     public String commonConfig;
 

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
@@ -120,11 +120,92 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
 
     @Override
     public CompletableFuture<Void> createTopics(List<TopicInfo> topicInfos) {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        Map<String, String> topicConfigs = new HashMap<>((Map) topicProperties);
-        KafkaTopicCreator topicCreator =
-                new KafkaTopicCreator(admin, topicConfigs, config.replicationFactor);
-        return topicCreator.create(topicInfos);
+        if (config.weightedTopicConfigs == null || config.weightedTopicConfigs.isEmpty()) {
+            return createAllWithConfig(topicInfos, baseTopicConfigs());
+        }
+        return createWithWeightedConfigs(topicInfos);
+    }
+
+    private CompletableFuture<Void> createAllWithConfig(
+            List<TopicInfo> topicInfos, Map<String, String> topicConfigs) {
+        return new KafkaTopicCreator(admin, topicConfigs, config.replicationFactor).create(topicInfos);
+    }
+
+    private CompletableFuture<Void> createWithWeightedConfigs(List<TopicInfo> topicInfos) {
+        int[] counts = allocateByWeight(topicInfos.size(), config.weightedTopicConfigs);
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        int offset = 0;
+        for (int i = 0; i < config.weightedTopicConfigs.size(); i++) {
+            int count = counts[i];
+            if (count == 0) {
+                continue;
+            }
+            List<TopicInfo> group = topicInfos.subList(offset, offset + count);
+            offset += count;
+
+            Map<String, String> merged = mergeConfigs(config.weightedTopicConfigs.get(i).config);
+            futures.add(createAllWithConfig(group, merged));
+        }
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Map<String, String> baseTopicConfigs() {
+        return new HashMap<>((Map) topicProperties);
+    }
+
+    private Map<String, String> mergeConfigs(String overrideConfig) {
+        Map<String, String> merged = baseTopicConfigs();
+        if (overrideConfig == null || overrideConfig.trim().isEmpty()) {
+            return merged;
+        }
+        Properties overrides = new Properties();
+        try {
+            overrides.load(new StringReader(overrideConfig));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse topic config override", e);
+        }
+        overrides.forEach((k, v) -> merged.put((String) k, (String) v));
+        return merged;
+    }
+
+    static int[] allocateByWeight(int total, List<WeightedTopicConfig> configs) {
+        double totalWeight = 0;
+        for (WeightedTopicConfig c : configs) {
+            totalWeight += c.weight;
+        }
+        if (totalWeight <= 0) {
+            throw new IllegalArgumentException("Total weight must be positive");
+        }
+
+        double[] exact = new double[configs.size()];
+        int[] counts = new int[configs.size()];
+        int allocated = 0;
+
+        for (int i = 0; i < configs.size(); i++) {
+            exact[i] = (configs.get(i).weight / totalWeight) * total;
+            counts[i] = (int) Math.floor(exact[i]);
+            allocated += counts[i];
+        }
+
+        int remaining = total - allocated;
+        while (remaining > 0) {
+            double maxFrac = -1;
+            int maxIdx = 0;
+            for (int i = 0; i < configs.size(); i++) {
+                double frac = exact[i] - counts[i];
+                if (frac > maxFrac) {
+                    maxFrac = frac;
+                    maxIdx = i;
+                }
+            }
+            counts[maxIdx]++;
+            exact[maxIdx] = counts[maxIdx];
+            remaining--;
+        }
+
+        return counts;
     }
 
     @Override

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/WeightedTopicConfig.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/WeightedTopicConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.kafka;
+
+/**
+ * A topic configuration with an associated weight for proportional distribution across topics. When
+ * multiple entries are specified, topics are allocated to each config proportionally based on the
+ * relative weights. Each entry's config is merged on top of the base {@code topicConfig} — so
+ * shared defaults go in {@code topicConfig} and per-group overrides go here.
+ */
+public class WeightedTopicConfig {
+    public double weight;
+    public String config;
+
+    public WeightedTopicConfig() {}
+
+    public WeightedTopicConfig(double weight, String config) {
+        this.weight = weight;
+        this.config = config;
+    }
+}

--- a/driver-kafka/src/test/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriverWeightedConfigTest.java
+++ b/driver-kafka/src/test/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriverWeightedConfigTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class KafkaBenchmarkDriverWeightedConfigTest {
+
+    @Nested
+    class AllocateByWeight {
+
+        @Test
+        void exactEvenSplit() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(0.5, "a"), new WeightedTopicConfig(0.5, "b"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(10, configs);
+
+            assertThat(counts).containsExactly(5, 5);
+        }
+
+        @Test
+        void unevenWeights() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(0.7, "a"), new WeightedTopicConfig(0.3, "b"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(10, configs);
+
+            assertThat(counts).containsExactly(7, 3);
+        }
+
+        @Test
+        void singleTopicGoesToFirstConfig() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(0.5, "a"), new WeightedTopicConfig(0.5, "b"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(1, configs);
+
+            assertThat(counts).containsExactly(1, 0);
+        }
+
+        @Test
+        void threeWaySplit() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(
+                            new WeightedTopicConfig(1, "a"),
+                            new WeightedTopicConfig(1, "b"),
+                            new WeightedTopicConfig(1, "c"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(10, configs);
+
+            assertThat(Arrays.stream(counts).sum()).isEqualTo(10);
+            for (int count : counts) {
+                assertThat(count).isBetween(3, 4);
+            }
+        }
+
+        @Test
+        void weightsAreNormalized() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(2.0, "a"), new WeightedTopicConfig(2.0, "b"));
+
+            int[] counts = KafkaBenchmarkDriver.allocateByWeight(6, configs);
+
+            assertThat(counts).containsExactly(3, 3);
+        }
+
+        @Test
+        void throwsOnZeroTotalWeight() {
+            List<WeightedTopicConfig> configs =
+                    Arrays.asList(new WeightedTopicConfig(0, "a"), new WeightedTopicConfig(0, "b"));
+
+            assertThatThrownBy(() -> KafkaBenchmarkDriver.allocateByWeight(10, configs))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <checkstyle.version>10.3.3</checkstyle.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
         <log4j.version>2.20.0</log4j.version>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.34</lombok.version>
         <jackson.version>2.13.2</jackson.version>
         <jcommander.version>1.48</jcommander.version>
         <junit.jupiter.version>5.9.0</junit.jupiter.version>
@@ -442,6 +442,13 @@
                                 <showDeprecation>true</showDeprecation>
                                 <showWarnings>true</showWarnings>
                                 <optimize>true</optimize>
+                                <annotationProcessorPaths>
+                                    <path>
+                                        <groupId>org.projectlombok</groupId>
+                                        <artifactId>lombok</artifactId>
+                                        <version>${lombok.version}</version>
+                                    </path>
+                                </annotationProcessorPaths>
                             </configuration>
                         </plugin>
                     </plugins>


### PR DESCRIPTION
Example workload:

```
name: produce-10GiB-over-30min-mi
produceBytesTarget: 10737418240   # 10 * 1024^3 bytes
testDurationMinutes: 0
warmupDurationMinutes: 0
topics: 4                 # even -> 2 diskless + 2 classic
partitionsPerTopic: 4
producerRate: 5826        # 5826 * 1024 B/s ≈ 5.69 MiB/s -> ~10 GiB in ~30 min
messageSize: 1024
useRandomizedPayloads: true
randomBytesRatio: 0.8
randomizedPayloadPoolSize: 1000
consumerBacklogSizeGB: 0
producersPerTopic: 1
subscriptionsPerTopic: 3
consumerPerSubscription: 1
```